### PR TITLE
fix: remove glitch in the stroke dash animation

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -28,48 +28,42 @@ footer {
 }
 
 
-/*css of running instances */
+/* Running instances */
 .task-running-on-time > rect {
     stroke-dasharray: 10, 5;
     animation-name: dash-task;
-    animation-duration: 3s;
+    animation-duration: 0.5s;
     animation-timing-function: linear;
     animation-iteration-count: infinite;
-    animation-direction: reverse;
     filter: drop-shadow(0 0 0.95em rgb(6, 146, 3));
 }
 
 .task-running-risky > rect {
     stroke-dasharray: 10, 5;
     animation-name: dash-task;
-    animation-duration: 8s;
+    animation-duration: 1s;
     animation-timing-function: linear;
     animation-iteration-count: infinite;
-    animation-direction: reverse;
     filter: drop-shadow(0 0 0.95em rgb(255, 119, 0));
 }
 
 .task-running-critical > rect {
     stroke-dasharray: 10, 5;
     animation-name: dash-task;
-    animation-duration: 15s;
+    animation-duration: 1.5s;
     animation-timing-function: linear;
     animation-iteration-count: infinite;
-    animation-direction: reverse;
     filter: drop-shadow(0 0 0.95em rgb(255, 0, 0));
 }
 
 @keyframes dash-task {
-    from {
-        stroke-dashoffset: 0;
-    }
     to {
-        stroke-dashoffset: 100;
+        stroke-dashoffset: -15;
     }
 }
 
-/* CSS of waiting process instances */
 
+/* Waiting instances */
 .path-waiting-critical > path:nth-child(2) {
     stroke: #ca0d0d;
     animation: pulsate 1.5s ease-out;


### PR DESCRIPTION
In the keyframes, the stroke-dashoffset final value wasn't a multiple of the stroke-dasharray. So, when the animation restarted, the final value of the previous frame wasn't equal to the start value of the new frame.
This was what causing the visual glitch.

### Notes

The animation speed has changed slightly. It can be adjusted to better fit with the previous rendering. At least, the speed ratio are kept.


### Visual fixes

On the left, main branch commit 0ce0ce55 , on the right the change proposed in this PR


https://user-images.githubusercontent.com/27200110/195093613-a64b0509-9a1e-481a-8a16-ebc132a0638e.mp4

